### PR TITLE
Change lightblock_off's recipe to use OreDict

### DIFF
--- a/src/main/resources/assets/rflux/recipes/lightblock_off.json
+++ b/src/main/resources/assets/rflux/recipes/lightblock_off.json
@@ -16,7 +16,8 @@
       "item": "minecraft:redstone"
     },
     "B": {
-      "item": "minecraft:glass"
+      "type": "forge:ore_dict",
+      "ore": "blockGlass"
     },
     "g": {
       "item": "minecraft:glowstone"


### PR DESCRIPTION
I had some clear glass and wanted to make a lightblock, but found I couldn't. If this is intentional, feel free to close.